### PR TITLE
Fixed loading empty container

### DIFF
--- a/src/editing/containerModelBinder.ts
+++ b/src/editing/containerModelBinder.ts
@@ -9,6 +9,10 @@ export class ContainerModelBinder {
     ) { }
 
     public async getChildModels(nodes: Contract[] = [], bindingContext: any): Promise<any[]> {
+        if (!nodes) {
+            return [];
+        }
+
         const modelPromises = nodes.map((contract: Contract) => {
             let modelBinder = this.widgetService.getModelBinder(contract.type);
 


### PR DESCRIPTION
When the container doesn't have any nodes `getChildModels()` is called with null, which throws an exception:
![image](https://user-images.githubusercontent.com/92857141/199973728-80fa28b7-ab93-440e-8555-f3a88b7d2c11.png)
